### PR TITLE
[Event_annotation] filter `isHidden` on expression level

### DIFF
--- a/src/plugins/event_annotation/common/event_annotation_group/index.ts
+++ b/src/plugins/event_annotation/common/event_annotation_group/index.ts
@@ -60,7 +60,7 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
     fn: (input, args) => {
       return {
         type: 'event_annotation_group',
-        annotations: args.annotations,
+        annotations: args.annotations.filter((annotation) => !annotation.isHidden),
         dataView: args.dataView,
       };
     },

--- a/src/plugins/event_annotation/public/event_annotation_service/service.tsx
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.tsx
@@ -25,9 +25,8 @@ export function hasIcon(icon: string | undefined): icon is string {
 
 export function getEventAnnotationService(): EventAnnotationServiceType {
   const annotationsToExpression = (annotations: EventAnnotationConfig[]) => {
-    const visibleAnnotations = annotations.filter(({ isHidden }) => !isHidden);
     const [queryBasedAnnotations, manualBasedAnnotations] = partition(
-      visibleAnnotations,
+      annotations,
       isQueryAnnotationConfig
     );
 
@@ -50,6 +49,7 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
                 label: [label || defaultAnnotationLabel],
                 color: [color || defaultAnnotationRangeColor],
                 outside: [Boolean(outside)],
+                isHidden: [Boolean(annotation.isHidden)],
               },
             },
           ],
@@ -71,6 +71,7 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
                 lineStyle: [lineStyle || 'solid'],
                 icon: hasIcon(icon) ? [icon] : ['triangle'],
                 textVisibility: [textVisibility || false],
+                isHidden: [Boolean(annotation.isHidden)],
               },
             },
           ],
@@ -112,6 +113,7 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
               filter: filter ? [queryToAst(filter)] : [],
               extraFields: extraFields || [],
               ignoreGlobalFilters: [Boolean(ignoreGlobalFilters)],
+              isHidden: [Boolean(annotation.isHidden)],
             },
           },
         ],

--- a/test/interpreter_functional/test_suites/run_pipeline/event_annotation/fetch_event_annotations.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/event_annotation/fetch_event_annotations.ts
@@ -47,7 +47,7 @@ export default function ({
     `;
       const result = await expectExpression('fetch_event_annotations', expression).getResponse();
 
-      expect(result.rows.length).to.equal(3);
+      expect(result.rows.length).to.equal(2);
       expect(result.rows).to.eql([
         {
           id: 'ann3',
@@ -69,16 +69,6 @@ export default function ({
           icon: 'bolt',
           lineWidth: 3,
           textVisibility: true,
-        },
-        {
-          id: 'ann2',
-          time: '2015-09-21T12:30:00Z',
-          timebucket: '2015-09-20T14:30:00.000Z',
-          type: 'point',
-          label: 'ManualHidden',
-          color: 'pink',
-          icon: 'triangle',
-          isHidden: true,
         },
       ]);
     });


### PR DESCRIPTION
Hey Michael, 

thank you for your PR fixing the functional test - it works well and it solves the problem. However, I think I made a mistake when moving filtering hidden annotations to the helper that is ran before running expressions. That causes potential problem when using expression directly on canvas and not through helper, so I changed the functionality back to filtering on expression level. If you're ok with this change, please merge it to your PR and I'll approve your PR :) 