### PR TITLE
Add regression coverage for HTTP listener socket write errors

### DIFF
--- a/src/core/server/integration_tests/http/socket_write_errors.test.ts
+++ b/src/core/server/integration_tests/http/socket_write_errors.test.ts
@@ -1,0 +1,438 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChildProcessWithoutNullStreams, ExecFileSyncOptions } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
+import { request as httpRequest, type Server } from 'http';
+import moment from 'moment';
+import { of } from 'rxjs';
+import { Readable } from 'stream';
+import { ByteSizeValue } from '@kbn/config-schema';
+import { mockCoreContext } from '@kbn/core-base-server-mocks';
+import type { HttpConfig } from '@kbn/core-http-server-internal';
+import { HttpServer } from '@kbn/core-http-server-internal';
+import { Router } from '@kbn/core-http-router-server-internal';
+import type { Logger } from '@kbn/logging';
+import { createTestEnv, getEnvOptions } from '@kbn/config-mocks';
+
+const envOptions = getEnvOptions();
+envOptions.cliArgs.dev = false;
+const env = createTestEnv({ envOptions });
+
+const delay = (durationMs: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+
+const runSudo = (args: string[], execOptions: ExecFileSyncOptions = {}) => {
+  const output = execFileSync('sudo', ['-n', ...args], {
+    encoding: 'utf8',
+    ...execOptions,
+  });
+
+  return typeof output === 'string' ? output.trim() : '';
+};
+
+const runSudoIgnoringError = (args: string[], execOptions: ExecFileSyncOptions = {}) => {
+  try {
+    runSudo(args, execOptions);
+  } catch {
+    // Best-effort cleanup.
+  }
+};
+
+const hasIptablesNetworkNamespaceSupport = () => {
+  if (process.platform !== 'linux') {
+    return false;
+  }
+
+  try {
+    runSudo(['true'], { stdio: 'ignore' });
+    runSudo(['iptables', '--version'], { stdio: 'ignore' });
+    runSudo(['ip', 'netns', 'list'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const describeIfIptablesSupported = hasIptablesNetworkNamespaceSupport() ? describe : describe.skip;
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: Error) => void;
+
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
+interface NetworkNamespaceHarness {
+  readonly name: string;
+  readonly hostIp: string;
+  readonly clientIp: string;
+  runInNamespace: (...args: string[]) => string;
+  killNamespaceProcesses: () => void;
+  cleanup: () => void;
+}
+
+const createNetworkNamespaceHarness = (): NetworkNamespaceHarness => {
+  const id = Math.floor(Math.random() * 1_000_000)
+    .toString(36)
+    .slice(0, 5);
+  const namespaceIndex = 20 + Math.floor(Math.random() * 200);
+  const name = `http-write-${id}`;
+  const hostInterface = `vh${id}`;
+  const clientInterface = `vc${id}`;
+  const hostIp = `10.200.${namespaceIndex}.1`;
+  const clientIp = `10.200.${namespaceIndex}.2`;
+
+  runSudo(['ip', 'netns', 'add', name], { stdio: 'ignore' });
+  runSudo(['ip', 'link', 'add', hostInterface, 'type', 'veth', 'peer', 'name', clientInterface], {
+    stdio: 'ignore',
+  });
+  runSudo(['ip', 'link', 'set', clientInterface, 'netns', name], { stdio: 'ignore' });
+  runSudo(['ip', 'addr', 'add', `${hostIp}/24`, 'dev', hostInterface], { stdio: 'ignore' });
+  runSudo(['ip', 'link', 'set', hostInterface, 'up'], { stdio: 'ignore' });
+  runSudo(
+    ['ip', 'netns', 'exec', name, 'ip', 'addr', 'add', `${clientIp}/24`, 'dev', clientInterface],
+    {
+      stdio: 'ignore',
+    }
+  );
+  runSudo(['ip', 'netns', 'exec', name, 'ip', 'link', 'set', 'lo', 'up'], { stdio: 'ignore' });
+  runSudo(['ip', 'netns', 'exec', name, 'ip', 'link', 'set', clientInterface, 'up'], {
+    stdio: 'ignore',
+  });
+
+  const killNamespaceProcesses = () => {
+    const pids = runSudo(['ip', 'netns', 'pids', name], { stdio: 'pipe' });
+    if (pids.length === 0) {
+      return;
+    }
+
+    runSudo(['kill', '-9', ...pids.split(/\s+/)], { stdio: 'ignore' });
+  };
+
+  const cleanup = () => {
+    killNamespaceProcesses();
+    runSudoIgnoringError(['ip', 'netns', 'del', name], { stdio: 'ignore' });
+    runSudoIgnoringError(['ip', 'link', 'del', hostInterface], { stdio: 'ignore' });
+  };
+
+  return {
+    name,
+    hostIp,
+    clientIp,
+    runInNamespace: (...args: string[]) => runSudo(['ip', 'netns', 'exec', name, ...args]),
+    killNamespaceProcesses,
+    cleanup,
+  };
+};
+
+const spawnNamespaceClient = ({
+  namespace,
+  hostIp,
+  port,
+  request,
+}: {
+  namespace: string;
+  hostIp: string;
+  port: number;
+  request: string;
+}): {
+  child: ChildProcessWithoutNullStreams;
+  localPort: Promise<number>;
+} => {
+  const localPortDeferred = createDeferred<number>();
+  const childCode = `
+    const net = require('net');
+    const socket = net.connect(
+      { host: ${JSON.stringify(hostIp)}, port: ${port} },
+      () => {
+        socket.write(${JSON.stringify(request)}, () => {
+          console.log(\`LOCAL_PORT:\${socket.localPort}\`);
+        });
+      }
+    );
+
+    setInterval(() => {}, 1000);
+  `;
+
+  const child = spawn(
+    'sudo',
+    ['-n', 'ip', 'netns', 'exec', namespace, process.execPath, '-e', childCode],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  let stdoutBuffer = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    stdoutBuffer += chunk.toString();
+    const match = stdoutBuffer.match(/LOCAL_PORT:(\d+)/);
+    if (match) {
+      localPortDeferred.resolve(Number(match[1]));
+    }
+  });
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    stdoutBuffer += chunk.toString();
+  });
+
+  child.once('exit', (code, signal) => {
+    localPortDeferred.reject(
+      new Error(
+        `Namespace client exited before reporting a port (code=${String(code)}, signal=${String(
+          signal
+        )}). Output: ${stdoutBuffer}`
+      )
+    );
+  });
+
+  return { child, localPort: localPortDeferred.promise };
+};
+
+const getListenerPort = (listener: Server): number => {
+  const address = listener.address();
+  if (address == null || typeof address === 'string') {
+    throw new Error('Expected HTTP server listener to expose an address object');
+  }
+
+  return address.port;
+};
+
+const requestText = async ({ host, port, path }: { host: string; port: number; path: string }) => {
+  return await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host,
+        port,
+        path,
+        method: 'GET',
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body,
+          });
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+};
+
+describeIfIptablesSupported('Http server socket write errors', () => {
+  jest.setTimeout(30_000);
+
+  let server: HttpServer;
+  let config: HttpConfig;
+  let logger: Logger;
+  let coreContext: ReturnType<typeof mockCoreContext.create>;
+
+  const enhanceWithContext = (fn: (...args: any[]) => any) => fn.bind(null, {});
+
+  beforeEach(() => {
+    coreContext = mockCoreContext.create();
+    logger = coreContext.logger.get();
+
+    config = {
+      name: 'kibana',
+      host: '127.0.0.1',
+      maxPayload: new ByteSizeValue(1024),
+      port: 0,
+      ssl: { enabled: false },
+      compression: { enabled: false, brotli: { enabled: false } },
+      requestId: {
+        allowFromAnyIp: true,
+        ipAllowlist: [],
+      },
+      cdn: {},
+      cors: {
+        enabled: false,
+      },
+      shutdownTimeout: moment.duration(5, 's'),
+      restrictInternalApis: false,
+    } as any;
+
+    server = new HttpServer(coreContext, 'tests', of(config.shutdownTimeout));
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('does not surface an uncaught exception when a delayed response hits a reset namespace client', async () => {
+    const namespace = createNetworkNamespaceHarness();
+    const requestStarted = createDeferred<void>();
+    let listener: Server | undefined;
+    let dropRuleArgs: string[] | undefined;
+    let uncaughtError: Error | undefined;
+    let uncaughtMonitorError: Error | undefined;
+    const onUncaughtException = (error: Error) => {
+      uncaughtError = error;
+    };
+    const onUncaughtExceptionMonitor = (error: Error) => {
+      uncaughtMonitorError = error;
+    };
+
+    process.prependOnceListener('uncaughtException', onUncaughtException);
+    process.prependOnceListener('uncaughtExceptionMonitor', onUncaughtExceptionMonitor);
+
+    try {
+      config = {
+        ...config,
+        host: namespace.hostIp,
+      };
+
+      const { registerRouter, server: innerServer } = await server.setup({ config$: of(config) });
+      listener = innerServer.listener;
+
+      const router = new Router('', logger, enhanceWithContext, {
+        env,
+        versionedRouterOptions: {
+          defaultHandlerResolutionStrategy: 'oldest',
+        },
+      });
+
+      router.get(
+        {
+          path: '/fault',
+          security: { authz: { enabled: false, reason: '' } },
+          validate: false,
+        },
+        async (_context, _req, res) => {
+          const stream = new Readable({
+            read() {},
+          });
+
+          requestStarted.resolve();
+
+          setTimeout(() => {
+            stream.push(Buffer.alloc(1024 * 1024));
+            stream.push(Buffer.alloc(1024 * 1024));
+            stream.push(Buffer.alloc(1024 * 1024));
+            stream.push(null);
+          }, 500);
+
+          return res.ok({ body: stream });
+        }
+      );
+
+      router.get(
+        {
+          path: '/health',
+          security: { authz: { enabled: false, reason: '' } },
+          validate: false,
+        },
+        (_context, _req, res) => {
+          return res.ok({ body: 'ok' });
+        }
+      );
+
+      registerRouter(router);
+
+      await server.start();
+
+      const port = getListenerPort(listener);
+      const { localPort } = spawnNamespaceClient({
+        namespace: namespace.name,
+        hostIp: namespace.hostIp,
+        port,
+        request: 'GET /fault HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n',
+      });
+
+      const clientPort = await localPort;
+      await requestStarted.promise;
+
+      dropRuleArgs = [
+        'iptables',
+        '-I',
+        'OUTPUT',
+        '-p',
+        'tcp',
+        '-s',
+        namespace.clientIp,
+        '--sport',
+        String(clientPort),
+        '-d',
+        namespace.hostIp,
+        '--dport',
+        String(port),
+        '-j',
+        'DROP',
+      ];
+
+      namespace.runInNamespace(...dropRuleArgs);
+      namespace.killNamespaceProcesses();
+      await delay(200);
+
+      namespace.runInNamespace(
+        'iptables',
+        '-D',
+        'OUTPUT',
+        '-p',
+        'tcp',
+        '-s',
+        namespace.clientIp,
+        '--sport',
+        String(clientPort),
+        '-d',
+        namespace.hostIp,
+        '--dport',
+        String(port),
+        '-j',
+        'DROP'
+      );
+      dropRuleArgs = undefined;
+
+      await delay(1000);
+
+      expect(uncaughtError).toBeUndefined();
+      expect(uncaughtMonitorError).toBeUndefined();
+
+      const healthResponse = await requestText({
+        host: namespace.hostIp,
+        port,
+        path: '/health',
+      });
+
+      expect(healthResponse).toEqual({
+        statusCode: 200,
+        body: 'ok',
+      });
+    } finally {
+      process.removeListener('uncaughtException', onUncaughtException);
+      process.removeListener('uncaughtExceptionMonitor', onUncaughtExceptionMonitor);
+
+      if (dropRuleArgs) {
+        const deleteRuleArgs = [...dropRuleArgs];
+        deleteRuleArgs[1] = '-D';
+        runSudoIgnoringError(['ip', 'netns', 'exec', namespace.name, ...deleteRuleArgs], {
+          stdio: 'ignore',
+        });
+      }
+
+      runSudoIgnoringError(['ip', 'netns', 'pids', namespace.name], { stdio: 'ignore' });
+      namespace.cleanup();
+    }
+  });
+});

--- a/src/platform/packages/shared/kbn-server-http-tools/src/get_listener.test.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/get_listener.test.ts
@@ -19,6 +19,11 @@ import { ByteSizeValue } from '@kbn/config-schema';
 import type { IHttpConfig } from './types';
 import { getServerListener } from './get_listener';
 
+const getEventHandler = <T>(onMock: jest.Mock, eventName: string): T | undefined =>
+  onMock.mock.calls.find(([registeredEventName]) => registeredEventName === eventName)?.[1] as
+    | T
+    | undefined;
+
 const createConfig = (parts: Partial<IHttpConfig>): IHttpConfig => ({
   host: 'localhost',
   protocol: 'http1',
@@ -53,6 +58,39 @@ describe('getServerListener', () => {
   });
 
   describe('When protocol is `http1`', () => {
+    it('registers a connection error handler that destroys sockets on EPIPE writes', () => {
+      const config = createConfig({ ssl: { enabled: false } });
+      const server = getServerListener(config);
+      const serverOnMock = server.on as jest.Mock;
+
+      const connectionHandler = getEventHandler<
+        (socket: { on: jest.Mock; destroy: jest.Mock }) => void
+      >(serverOnMock, 'connection');
+
+      expect(connectionHandler).toBeDefined();
+
+      const socket = {
+        on: jest.fn(),
+        destroy: jest.fn(),
+      };
+
+      connectionHandler!(socket);
+
+      const errorHandler = getEventHandler<(error: NodeJS.ErrnoException) => void>(
+        socket.on,
+        'error'
+      );
+
+      expect(errorHandler).toBeDefined();
+
+      const epipeError = Object.assign(new Error('write EPIPE'), {
+        code: 'EPIPE',
+      }) as NodeJS.ErrnoException;
+
+      expect(() => errorHandler!(epipeError)).not.toThrow();
+      expect(socket.destroy).toHaveBeenCalledWith(epipeError);
+    });
+
     describe('when TLS is enabled', () => {
       it('calls getServerTLSOptions with the correct parameters', () => {
         const config = createConfig({ ssl: { enabled: true } });
@@ -84,7 +122,6 @@ describe('getServerListener', () => {
         expect(server.setTimeout).toHaveBeenCalledTimes(1);
         expect(server.setTimeout).toHaveBeenCalledWith(config.socketTimeout);
 
-        expect(server.on).toHaveBeenCalledTimes(2);
         expect(server.on).toHaveBeenCalledWith('clientError', expect.any(Function));
         expect(server.on).toHaveBeenCalledWith('timeout', expect.any(Function));
       });
@@ -129,7 +166,6 @@ describe('getServerListener', () => {
         expect(server.setTimeout).toHaveBeenCalledTimes(1);
         expect(server.setTimeout).toHaveBeenCalledWith(config.socketTimeout);
 
-        expect(server.on).toHaveBeenCalledTimes(2);
         expect(server.on).toHaveBeenCalledWith('clientError', expect.any(Function));
         expect(server.on).toHaveBeenCalledWith('timeout', expect.any(Function));
       });

--- a/src/platform/packages/shared/kbn-server-http-tools/src/get_listener.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/get_listener.ts
@@ -17,6 +17,9 @@ interface GetServerListenerOptions {
   configureTLS?: boolean;
 }
 
+const isRecoverableSocketError = (error: NodeJS.ErrnoException): boolean =>
+  error.code === 'EPIPE' || error.code === 'ECONNRESET';
+
 export function getServerListener(
   config: IHttpConfig,
   options: GetServerListenerOptions = {}
@@ -46,6 +49,15 @@ const configureHttp1Listener = (
   listener.setTimeout(config.socketTimeout);
   listener.on('timeout', (socket) => {
     socket.destroy();
+  });
+  listener.on('connection', (socket) => {
+    socket.on('error', (error) => {
+      if (isRecoverableSocketError(error)) {
+        socket.destroy(error);
+      } else {
+        throw error;
+      }
+    });
   });
   listener.on('clientError', (err, socket) => {
     if (socket.writable) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add regression coverage for HTTP/1 socket write failures in Kibana's server listener stack.

- attach a connection-level socket error handler in `kbn-server-http-tools` for recoverable socket write failures
- treat `EPIPE` and `ECONNRESET` as recoverable connection errors and destroy the socket instead of letting the error escape as an uncaught exception
- add a focused unit test in `get_listener.test.ts` for the missing-handler path
- add a Linux-only HTTP integration test that uses `ip netns` + `iptables` to force a delayed response into a reset client connection and assert Kibana does not surface an uncaught exception and remains healthy

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [x] Low risk: the production code change is limited to HTTP/1 connection error handling and only intercepts recoverable socket errors (`EPIPE` and `ECONNRESET`).
- [x] Medium test-environment risk: the new integration test depends on Linux networking features (`sudo`, `ip netns`, `iptables`) and is explicitly gated to skip when that support is unavailable.
- [x] Mitigation: targeted unit coverage validates the listener contract directly, and the integration test exercises the end-to-end network failure path with cleanup for namespace and firewall state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ac523a2-2bfc-40ec-9745-b3eaeb499185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ac523a2-2bfc-40ec-9745-b3eaeb499185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

